### PR TITLE
add vertical align incase contents of each column are not the same.

### DIFF
--- a/patterns/lists/list-with-thumbnails.html
+++ b/patterns/lists/list-with-thumbnails.html
@@ -128,7 +128,7 @@
         <td width="600" style="padding: 30px 0; border-top: 1px solid #ccc; border-bottom: 1px solid #ccc;">
             <table cellpadding="0" cellspacing="0">
                 <tr>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px;  vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -141,7 +141,7 @@
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px;  vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -154,7 +154,7 @@
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px;  vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -167,7 +167,7 @@
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px;  vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>

--- a/source/patterns/lists/list-with-thumbnails.erb
+++ b/source/patterns/lists/list-with-thumbnails.erb
@@ -53,7 +53,7 @@ title: List with Thumbnails
         <td width="600" style="padding: 30px 0; border-top: 1px solid #ccc; border-bottom: 1px solid #ccc;">
             <table cellpadding="0" cellspacing="0">
                 <tr>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px; vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -66,7 +66,7 @@ title: List with Thumbnails
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px; vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -79,7 +79,7 @@ title: List with Thumbnails
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px; vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>
@@ -92,7 +92,7 @@ title: List with Thumbnails
                             </tr>
                         </table>
                     </td>
-                    <td class="col" width="140" style="padding: 0 5px;">
+                    <td class="col" width="140" style="padding: 0 5px; vertical-align: top;">
                         <table cellpadding="0" cellspacing="0">
                             <tr>
                                 <td align="left"><img src="http://placehold.it/190x190/333333&text=Thumbnail" width="140" alt="" style="display: block; border: 0;" /></td>


### PR DESCRIPTION
if the text in the columns in "list-with-thumbnails.html" (and list-with-thumbnails.erb) is of varying size (which is likely), the columns don't all start at the top -- that's because the columns end up being vertically centered.

the simple fix is to set vertical align for the containing cell to be top.
